### PR TITLE
Fix Monitor.close() not flushing recorders

### DIFF
--- a/gym/wrappers/monitor.py
+++ b/gym/wrappers/monitor.py
@@ -133,10 +133,6 @@ class Monitor(Wrapper):
         """Flush all monitor data to disk and close any open rending windows."""
         super(Monitor, self).close()
 
-        # _monitor will not be set if super(Monitor, self).__init__ raises, this check prevents a confusing error message
-        if not hasattr(self, '_monitor'):
-            return
-
         if not self.enabled:
             return
         self.stats_recorder.close()


### PR DESCRIPTION
The _monitor field is never set. This code used to belong to a duplicate close() that was never called before https://github.com/openai/gym/pull/1321 was merged.